### PR TITLE
fix article titles and simplify listings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,11 @@ relative_links:
   enabled: true
   collections: true
 
+# Keep article titles stable: use explicit front matter titles when present,
+# otherwise let the layouts fall back to the Markdown filename.
+titles_from_headings:
+  enabled: false
+
 defaults:
   - scope:
       path: "AI"

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -4,16 +4,6 @@ layout: default
 {% assign dated_articles = site.pages | where_exp: 'item', 'item.date != nil' %}
 {% assign articles = dated_articles | where_exp: 'item', 'item.path contains page.category_path' | sort: 'date' | reverse %}
 <main class="listing-page">
-  <header class="listing-hero">
-    <a class="back-link" href="{{ '/' | relative_url }}">← 返回首页</a>
-    <p class="section-kicker">{{ page.kicker }}</p>
-    <div class="listing-title-row">
-      <h1>{{ page.title }}</h1>
-      <span>{{ articles.size }}</span>
-    </div>
-    <p>{{ page.description }}</p>
-  </header>
-
   <section class="listing-content" aria-label="{{ page.title }}文章列表">
     <div class="filter-row">
       <label class="inline-filter">

--- a/archive.html
+++ b/archive.html
@@ -6,17 +6,7 @@ description: 按时间浏览 Yano's Notes 的全部文章。
 ---
 {% assign articles = site.pages | where_exp: 'item', 'item.date != nil' | sort: 'date' | reverse %}
 <main class="listing-page archive-page">
-  <header class="listing-hero">
-    <a class="back-link" href="{{ '/' | relative_url }}">← 返回首页</a>
-    <p class="section-kicker">THE COMPLETE ARCHIVE</p>
-    <div class="listing-title-row">
-      <h1>文章归档</h1>
-      <span>{{ articles.size }}</span>
-    </div>
-    <p>从最近写下的内容开始，沿着时间回看这份持续生长的知识档案。</p>
-  </header>
-
-  <section class="archive-content">
+  <section class="archive-content" aria-label="文章归档">
     <div class="filter-row">
       <label class="inline-filter">
         <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="6.75"></circle><path d="m16 16 4.25 4.25"></path></svg>


### PR DESCRIPTION
## What changed

- disable automatic title inference from the first Markdown heading
- keep the existing filename fallback for all article titles
- remove the decorative hero from the archive page
- remove the decorative hero from all six category pages
- keep filters, article counts, and article lists intact

## Root cause

GitHub Pages loads `jekyll-titles-from-headings`, which populated `page.title` from the first heading when front matter had no title. Many articles begin with `# 前言`, so their filenames were incorrectly replaced by `前言` in lists and article pages.

## Validation

- Jekyll YAML configuration parses and disables `titles_from_headings`
- Liquid 4 strict parsing passes for the archive and category templates
- `git diff --check` passes