### PR TITLE
remove listing hero remnants

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,7 +17,6 @@ description: 关于 Yano 与这个持续生长的个人知识博客。
       <h2>一切从《Java 编程思想》开始</h2>
       <p>最初，我只是把读书时整理的思维导图截图发布到简书；收到许多读者留言后，便创建了这个项目，将完整笔记持续沉淀下来。</p>
       <p>后来内容逐渐越过了 Java 的边界，从编程与源码分析，延伸到 AI、读书、观影、游戏和生活随笔。<code>Thinking_in_Java_MindMapping</code> 这个名字已经无法概括这里的一切，但它保留了整个知识库最初的起点。</p>
-      <blockquote>Think deeply. Learn continuously. Write things down.</blockquote>
       <h2>现在关注什么</h2>
       <p>我仍然关注 Java 生态、分布式系统与底层原理，也在持续探索 AI Agent、MCP 和人与智能工具协作的新方式。技术之外，我同样认真对待书、电影、游戏和日常生活。</p>
     </article>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -841,11 +841,6 @@ html[data-theme="dark"] .moon-icon {
   padding-block: 70px 120px;
 }
 
-.listing-hero {
-  max-width: 850px;
-  margin-bottom: 75px;
-}
-
 .back-link {
   display: inline-block;
   margin-bottom: 60px;
@@ -859,19 +854,11 @@ html[data-theme="dark"] .moon-icon {
   color: var(--ink);
 }
 
-.listing-hero .section-kicker,
 .about-hero .section-kicker {
   margin-bottom: 14px;
   color: var(--orange);
 }
 
-.listing-title-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 20px;
-}
-
-.listing-title-row h1,
 .about-hero h1 {
   margin: 0;
   font-family: var(--serif);
@@ -881,21 +868,6 @@ html[data-theme="dark"] .moon-icon {
   line-height: 0.95;
 }
 
-.listing-title-row > span {
-  min-width: 40px;
-  height: 26px;
-  margin-top: 9px;
-  display: grid;
-  place-items: center;
-  padding-inline: 8px;
-  color: #171a20;
-  background: var(--acid);
-  border-radius: 20px;
-  font-family: var(--mono);
-  font-size: 10px;
-}
-
-.listing-hero > p:last-child,
 .about-hero > p:last-child {
   max-width: 600px;
   margin: 27px 0 0;
@@ -1929,8 +1901,6 @@ html[data-theme="dark"] .moon-icon {
   .listing-page,
   .about-page { padding-block: 45px 90px; }
   .back-link { margin-bottom: 45px; }
-  .listing-hero { margin-bottom: 55px; }
-  .listing-title-row h1,
   .about-hero h1 { font-size: 65px; }
   .listing-content,
   .archive-content { margin: 0; }

--- a/categories/ai.html
+++ b/categories/ai.html
@@ -3,6 +3,5 @@ layout: category
 title: AI
 permalink: /categories/ai/
 category_path: AI/
-kicker: ARTIFICIAL INTELLIGENCE
 description: 关注 Agent、MCP、AI 论文，以及智能工具带来的新工作方式。
 ---

--- a/categories/books.html
+++ b/categories/books.html
@@ -3,6 +3,5 @@ layout: category
 title: 读书
 permalink: /categories/books/
 category_path: 读书/
-kicker: READING & NOTES
 description: 从技术经典到人文社科，留下值得反复阅读的片段与思考。
 ---

--- a/categories/code.html
+++ b/categories/code.html
@@ -3,6 +3,5 @@ layout: category
 title: 编程
 permalink: /categories/code/
 category_path: 编程/
-kicker: CODE & ENGINEERING
 description: 从语言特性到源码实现，记录工程实践背后的原理。
 ---

--- a/categories/essays.html
+++ b/categories/essays.html
@@ -3,6 +3,5 @@ layout: category
 title: 随笔
 permalink: /categories/essays/
 category_path: 随笔/
-kicker: LIFE & THOUGHTS
 description: 关于生活、工作、成长与时间的零散记录。
 ---

--- a/categories/films.html
+++ b/categories/films.html
@@ -3,6 +3,5 @@ layout: category
 title: 观影
 permalink: /categories/films/
 category_path: 观影/
-kicker: FILMS & STORIES
 description: 电影、剧集与年度观影回顾，记录故事留下的回声。
 ---

--- a/categories/games.html
+++ b/categories/games.html
@@ -3,6 +3,5 @@ layout: category
 title: 游戏
 permalink: /categories/games/
 category_path: 游戏/
-kicker: GAMES & WORLDS
 description: JRPG、任天堂和那些让人愿意在另一个世界停留的作品。
 ---


### PR DESCRIPTION
## What changed

- remove unused category kicker metadata from all six category pages
- remove CSS that was only used by the deleted archive and category hero blocks
- remove the English quote from the About page
- keep category descriptions for page metadata and SEO

## Why

The visible hero blocks were already removed from the listing templates. This follow-up removes their remaining data and styling so the deleted presentation cannot linger in the codebase.

## Validation

- all category front matter parses successfully
- About page passes strict Liquid 4 parsing
- no `listing-hero`, `listing-title-row`, or category `kicker` references remain
- `git diff --check` passes