### PR TITLE
Add Giscus comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,13 @@ url: "https://ljyyano.github.io"
 baseurl: "/Thinking_in_Java_MindMapping"
 repository: "LjyYano/Thinking_in_Java_MindMapping"
 
+comments:
+  provider: giscus
+  repo: "LjyYano/Thinking_in_Java_MindMapping"
+  repo_id: "MDEwOlJlcG9zaXRvcnkxMDMyMjk4MzY="
+  category: "General"
+  category_id: "MDE4OkRpc2N1c3Npb25DYXRlZ29yeTMyMDM2NjAz"
+
 markdown: kramdown
 highlighter: rouge
 strict_front_matter: true

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,0 +1,22 @@
+<section
+  class="comments-section"
+  aria-labelledby="comments-title"
+  data-giscus-comments
+  data-repo="{{ site.comments.repo | escape }}"
+  data-repo-id="{{ site.comments.repo_id | escape }}"
+  data-category="{{ site.comments.category | escape }}"
+  data-category-id="{{ site.comments.category_id | escape }}"
+  data-term="{{ page.path | escape }}"
+>
+  <header class="comments-header">
+    <p class="comments-kicker">DISCUSSION</p>
+    <h2 id="comments-title">评论</h2>
+    <p>使用 GitHub 登录后即可参与讨论。</p>
+  </header>
+  <div class="giscus" data-giscus-container>
+    <p class="comments-loading">正在加载评论…</p>
+  </div>
+  <noscript>
+    <p class="comments-noscript">请启用 JavaScript 以查看和参与评论。</p>
+  </noscript>
+</section>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -41,6 +41,10 @@ layout: default
         <a href="https://github.com/{{ site.repository }}/edit/master/{{ page.path }}" target="_blank" rel="noopener">在 GitHub 上编辑</a>
       </div>
     </footer>
+
+    {% if site.comments.provider == 'giscus' %}
+      {% include comments.html %}
+    {% endif %}
   </article>
 
   <aside class="article-aside" aria-label="文章目录">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1435,6 +1435,50 @@ html[data-theme="dark"] .moon-icon {
   text-underline-offset: 5px;
 }
 
+.comments-section {
+  margin-top: 70px;
+  padding-top: 48px;
+  border-top: 1px solid var(--line-strong);
+}
+
+.comments-header {
+  margin-bottom: 32px;
+}
+
+.comments-kicker {
+  margin: 0 0 9px;
+  color: var(--orange);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+}
+
+.comments-header h2 {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: clamp(34px, 5vw, 48px);
+  font-weight: 500;
+  letter-spacing: -0.035em;
+  line-height: 1.2;
+}
+
+.comments-header > p:last-child,
+.comments-loading,
+.comments-noscript {
+  margin: 10px 0 0;
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+
+.giscus {
+  min-height: 180px;
+}
+
+.giscus-frame {
+  color-scheme: light dark;
+}
+
 /* About and 404 */
 .about-page {
   padding-block: 70px 130px;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -13,16 +13,73 @@
   var themeToggle = document.querySelector('[data-theme-toggle]');
   var themeColor = document.querySelector('meta[name="theme-color"]');
 
+  function getGiscusTheme(theme) {
+    return theme === 'dark' ? 'dark_dimmed' : 'light';
+  }
+
+  function syncGiscusTheme(theme) {
+    var frame = document.querySelector('iframe.giscus-frame');
+    if (!frame || !frame.contentWindow) return;
+    frame.contentWindow.postMessage({
+      giscus: {
+        setConfig: {
+          theme: getGiscusTheme(theme)
+        }
+      }
+    }, 'https://giscus.app');
+  }
+
   function applyTheme(theme) {
     root.dataset.theme = theme;
     localStorage.setItem('yano-theme', theme);
     if (themeColor) themeColor.setAttribute('content', theme === 'dark' ? '#141619' : '#f6f4ef');
+    syncGiscusTheme(theme);
   }
 
   if (themeToggle) {
     themeToggle.addEventListener('click', function () {
       applyTheme(root.dataset.theme === 'dark' ? 'light' : 'dark');
     });
+  }
+
+  // GitHub Discussions comments via giscus.
+  var commentsRoot = document.querySelector('[data-giscus-comments]');
+  if (commentsRoot) {
+    var commentsContainer = commentsRoot.querySelector('[data-giscus-container]');
+    var giscusScript = document.createElement('script');
+    var giscusObserver = null;
+
+    giscusScript.src = 'https://giscus.app/client.js';
+    giscusScript.async = true;
+    giscusScript.crossOrigin = 'anonymous';
+    giscusScript.dataset.repo = commentsRoot.dataset.repo;
+    giscusScript.dataset.repoId = commentsRoot.dataset.repoId;
+    giscusScript.dataset.category = commentsRoot.dataset.category;
+    giscusScript.dataset.categoryId = commentsRoot.dataset.categoryId;
+    giscusScript.dataset.mapping = 'specific';
+    giscusScript.dataset.term = commentsRoot.dataset.term;
+    giscusScript.dataset.strict = '1';
+    giscusScript.dataset.reactionsEnabled = '1';
+    giscusScript.dataset.emitMetadata = '0';
+    giscusScript.dataset.inputPosition = 'top';
+    giscusScript.dataset.theme = getGiscusTheme(root.dataset.theme);
+    giscusScript.dataset.lang = 'zh-CN';
+    giscusScript.dataset.loading = 'lazy';
+
+    if ('MutationObserver' in window) {
+      giscusObserver = new MutationObserver(function () {
+        var frame = commentsContainer.querySelector('iframe.giscus-frame');
+        if (!frame) return;
+        frame.addEventListener('load', function () {
+          syncGiscusTheme(root.dataset.theme);
+        }, { once: true });
+        syncGiscusTheme(root.dataset.theme);
+        giscusObserver.disconnect();
+      });
+      giscusObserver.observe(commentsContainer, { childList: true, subtree: true });
+    }
+
+    commentsContainer.replaceChildren(giscusScript);
   }
 
   // Mobile navigation


### PR DESCRIPTION
## What changed

- add a Giscus-powered comment section to every article
- store repository and Discussion category identifiers in the site configuration
- map discussions to stable article file paths
- synchronize the embedded comment theme with the blog light/dark theme
- add responsive styling that matches the existing article design

## Why

Readers currently have no way to discuss an article from the blog. Giscus adds public comments through the repository's existing GitHub Discussions without introducing a separate backend.

## Validation

- `git diff --check`
- `node --check assets/js/main.js`
- YAML configuration parsed successfully
- Giscus repository/category API returned the configured IDs
- real browser preview loaded the Chinese comment editor and GitHub sign-in entry

A full local Jekyll build was unavailable because the system Ruby is 2.6 while the pinned Nokogiri dependency requires Ruby 3; GitHub Pages CI will perform the production build.